### PR TITLE
Allow caching of JSON offset data

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -12,7 +12,7 @@
             "console": "integratedTerminal",
             "args": [
                 "--mode=default",
-                "--json-dir=${workspaceFolder}/maseya/z3pr/data/",
+                "--data-dir=${workspaceFolder}/maseya/z3pr/data/",
                 "./test_rom.sfc"
             ]
         }

--- a/maseya/z3pr/__init__.py
+++ b/maseya/z3pr/__init__.py
@@ -5,5 +5,9 @@ Randomize palette data for Legend of Zelda: A Link to the Past.
 from .color_f import ColorF
 from .snes_color import SnesColor
 from .options import get_options, get_options_from_anywhere
-from .palette_randomizer import randomize, randomize_from_options
+from .palette_randomizer import (
+    randomize,
+    randomize_from_options,
+    random_color_generator,
+)
 from .maseya_blend import maseya_blend

--- a/maseya/z3pr/color_f.py
+++ b/maseya/z3pr/color_f.py
@@ -28,43 +28,43 @@ class ColorF:
         return cls(1 - cyan, 1 - magenta, 1 - yellow)
 
     @property
-    def red(self):
+    def red(self) -> float:
         return self.__red
 
     @property
-    def green(self):
+    def green(self) -> float:
         return self.__green
 
     @property
-    def blue(self):
+    def blue(self) -> float:
         return self.__blue
 
     @property
-    def cyan(self):
+    def cyan(self) -> float:
         return 1 - self.__red
 
     @property
-    def magenta(self):
+    def magenta(self) -> float:
         return 1 - self.__green
 
     @property
-    def yellow(self):
+    def yellow(self) -> float:
         return 1 - self.__blue
 
     @property
-    def max_of_rgb(self):
+    def max_of_rgb(self) -> float:
         return max([self.__red, self.__green, self.__blue])
 
     @property
-    def min_of_rgb(self):
+    def min_of_rgb(self) -> float:
         return min([self.__red, self.__green, self.__blue])
 
     @property
-    def chroma(self):
+    def chroma(self) -> float:
         return self.max_of_rgb - self.min_of_rgb
 
     @property
-    def luma(self):
+    def luma(self) -> float:
         return (
             (LUMA_RED_WEIGHT * self.__red)
             + (LUMA_GREEN_WEIGHT * self.__green)
@@ -72,17 +72,17 @@ class ColorF:
         )
 
     @property
-    def lightness(self):
+    def lightness(self) -> float:
         return (self.max_of_rgb + self.min_of_rgb) / 2
 
     @property
-    def saturation(self):
+    def saturation(self) -> float:
         if self.lightness == 0 or self.lightness == 1:
             return 0
         return clamp(self.chroma / (1 - abs((2 * self.lightness) - 1)), 0, 1)
 
     @property
-    def hue(self):
+    def hue(self) -> float:
         # Technically, NaN should be returned, but returning 0 helps performance.
         if self.chroma == 0:
             return 0
@@ -101,10 +101,10 @@ class ColorF:
         return hue / 6.0
 
     @property
-    def hue_degrees(self):
+    def hue_degrees(self) -> float:
         return self.hue * 360
 
-    def __eq__(self, value):
+    def __eq__(self, value) -> bool:
         return (
             isinstance(value, ColorF)
             and self.__red == value.red
@@ -112,7 +112,7 @@ class ColorF:
             and self.__blue == value.blue
         )
 
-    def __ne__(self, value):
+    def __ne__(self, value) -> bool:
         return not self == value
 
     @property
@@ -184,11 +184,11 @@ class ColorF:
     def grayscale(self):
         return self.from_hcy(0, 0, self.luma)
 
-    def __hash__(self):
+    def __hash__(self) -> int:
         return hash((self.red, self.green, self.blue))
 
     def __str__(self) -> str:
         return f"{{R:{self.red};G:{self.green};B:{self.blue}}}"
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return str(self)

--- a/maseya/z3pr/palette_editor.py
+++ b/maseya/z3pr/palette_editor.py
@@ -1,6 +1,6 @@
 """Define the PaletteEditor class."""
 
-from typing import Callable, List, Mapping
+from typing import Callable, Iterable, List, Mapping
 
 from .snes_color import SnesColor
 from .color_f import ColorF
@@ -30,11 +30,11 @@ class PaletteEditor:
     def blend(
         self,
         blend: Callable[[ColorF, ColorF], ColorF],
-        get_color: Callable[[], ColorF],
+        color_generator: Iterable[ColorF],
     ):
         """Blend palette data using blend function and color generator."""
         # Get base color from passed funcion.
-        base_color = get_color()
+        base_color = next(color_generator)
 
         # Blend each color in the palette editor.
         for offset in self.__items.keys():
@@ -53,10 +53,10 @@ class PaletteEditor:
     def blend_by_color(
         self,
         blend: Callable[[ColorF, ColorF], ColorF],
-        get_color: Callable[[], ColorF],
+        color_generator: Iterable[ColorF],
     ):
         for color, offsets in self.get_color_groups().items():
-            new_color = blend(color, get_color())
+            new_color = blend(color, next(color_generator))
             for offset in offsets:
                 self.__items[offset] = new_color
 

--- a/maseya/z3pr/palette_editor.py
+++ b/maseya/z3pr/palette_editor.py
@@ -1,6 +1,6 @@
 """Define the PaletteEditor class."""
 
-from typing import Callable, List
+from typing import Callable, List, Mapping
 
 from .snes_color import SnesColor
 from .color_f import ColorF
@@ -40,7 +40,7 @@ class PaletteEditor:
         for offset in self.__items.keys():
             self.__items[offset] = blend(self.__items[offset], base_color)
 
-    def get_color_groups(self):
+    def get_color_groups(self) -> Mapping[ColorF, List[int]]:
         result = dict()
         for offset, color in self.__items.items():
             colors = result.get(color, None)

--- a/maseya/z3pr/palette_randomizer.py
+++ b/maseya/z3pr/palette_randomizer.py
@@ -4,7 +4,8 @@ import json
 import os
 from random import Random
 
-from typing import List, Mapping
+from itertools import cycle
+from typing import Iterable, List, Mapping
 
 from .color_f import ColorF
 from .palette_editor import PaletteEditor
@@ -33,29 +34,42 @@ def build_offsets_array(
             return _read_internal_json(f"{name}.json", json_dir)
         return []
 
-    offsets = []
+    result = []
     # TODO(bonimy): Add the other palette data like sprites.
     for name in ["dungeon", "hud", "link_sprite", "sword", "shield", "overworld"]:
-        offsets.extend(try_get_offset_array(name))
-    return offsets
+        result.extend(try_get_offset_array(name))
+    return result
 
 
-def _random_color_generator(seed: int = -1):
-    """Generate random colors with an optional seed value."""
+def cache_offsets_array(json_dir: str = None) -> Mapping[str, List[List[int]]]:
+    result = dict()
+    for name in ["dungeon", "hud", "link_sprite", "sword", "shield", "overworld"]:
+        result[f"randomize_{name}"] = _read_internal_json(f"{name}.json", json_dir)
+    return result
+
+
+def iterate_offsets_array_cache(
+    offsets_array: Mapping[str, List[List[int]]], options: Mapping[str, bool]
+) -> Iterable[List[int]]:
+    for name, is_set in options.items():
+        if is_set:
+            for offsets in offsets_array.get(name, []):
+                yield offsets
+
+
+def _random_color_generator(seed: int = -1) -> Iterable[ColorF]:
+    """Infinitely iterates random colors with an optional seed value."""
     random = Random(seed) if seed != -1 else Random()
 
-    def next_color():
-        return ColorF(random.random(), random.random(), random.random())
-
-    return next_color
+    while True:
+        yield ColorF(random.random(), random.random(), random.random())
 
 
 def randomize(
     rom: bytearray,
     mode: str,
-    next_color=None,
-    options: dict = None,
-    json_dir: str = None,
+    offsets_iterator: Iterable[List[int]],
+    color_generator: Iterable[ColorF] = None,
 ):
     """Randomize palette data in a rom."""
     # We want to do case-invariant searches
@@ -66,30 +80,26 @@ def randomize(
         return
 
     # Create standard random generator if no generator was given.
-    if not next_color:
-        next_color = _random_color_generator()
-
-    # Get array of offset collections. Each offset collection specifies a grouping
-    # palette data that should be blended by the same rules.
-    offsets_array = build_offsets_array(options, json_dir)
+    if not color_generator:
+        color_generator = _random_color_generator()
 
     # Create a palette editor for each offset collection.
-    palette_editors = [PaletteEditor(rom, offsets) for offsets in offsets_array]
+    palette_editors = [PaletteEditor(rom, offsets) for offsets in offsets_iterator]
 
     # Get the basic algorithms and offer some variant spellings just in case.
     algorithm_tuples = {
-        "maseya": [maseya_blend, next_color, PaletteEditor.blend],
-        "grayscale": [lambda x, y: x.grayscale, lambda: None, PaletteEditor.blend],
-        "negative": [lambda x, y: x.inverse, lambda: None, PaletteEditor.blend],
-        "blackout": [lambda x, y: y, lambda: ColorF(0, 0, 0), PaletteEditor.blend],
-        "classic": [acid_blend, next_color, PaletteEditor.blend],
-        "dizzy": [ColorF.hue_blend, next_color, PaletteEditor.blend_by_color,],
+        "maseya": [maseya_blend, color_generator, PaletteEditor.blend],
+        "grayscale": [lambda x, y: x.grayscale, cycle([None]), PaletteEditor.blend],
+        "negative": [lambda x, y: x.inverse, cycle([None]), PaletteEditor.blend],
+        "blackout": [lambda x, y: y, cycle([ColorF(0, 0, 0)]), PaletteEditor.blend],
+        "classic": [acid_blend, color_generator, PaletteEditor.blend],
+        "dizzy": [ColorF.hue_blend, color_generator, PaletteEditor.blend_by_color,],
         "sick": [
             lambda x, y: ColorF.luma_blend(y, x),
-            next_color,
+            color_generator,
             PaletteEditor.blend_by_color,
         ],
-        "puke": [lambda x, y: y, next_color, PaletteEditor.blend_by_color],
+        "puke": [lambda x, y: y, color_generator, PaletteEditor.blend_by_color],
     }
     algorithm_tuples["default"] = algorithm_tuples["maseya"]
     algorithm_tuples["greyscale"] = algorithm_tuples["grayscale"]
@@ -98,11 +108,11 @@ def randomize(
     algorithm_tuples["inverted"] = algorithm_tuples["negative"]
 
     # Now see which algorithm tuple we actually want.
-    color_blend, get_next_color, palette_blend = algorithm_tuples[mode]
+    color_blend, color_generator, palette_blend = algorithm_tuples[mode]
 
     # Blend colors in each palette editor then write it back to rom.
     for palette_editor in palette_editors:
-        palette_blend(palette_editor, color_blend, get_next_color)
+        palette_blend(palette_editor, color_blend, color_generator)
         palette_editor.write_to_rom(rom)
 
 
@@ -130,8 +140,12 @@ def randomize_from_options(options):
     with open(input_path, mode="rb") as stream:
         rom = bytearray(stream.read())
 
+    # Get array of offset collections. Each offset collection specifies a grouping
+    # palette data that should be blended by the same rules.
+    offsets_array = build_offsets_array(options, json_dir)
+
     # Randomize ROM data.
-    randomize(rom, options.pop("mode", "default"), next_color, options, json_dir)
+    randomize(rom, options.pop("mode", "default"), next_color, offsets_array)
 
     # Write results to output file.
     with open(output_path, mode="wb") as stream:

--- a/maseya/z3pr/palette_randomizer.py
+++ b/maseya/z3pr/palette_randomizer.py
@@ -57,7 +57,7 @@ def iterate_offsets_array_cache(
                 yield offsets
 
 
-def _random_color_generator(seed: int = -1) -> Iterable[ColorF]:
+def random_color_generator(seed: int = -1) -> Iterable[ColorF]:
     """Infinitely iterates random colors with an optional seed value."""
     random = Random(seed) if seed != -1 else Random()
 
@@ -81,7 +81,7 @@ def randomize(
 
     # Create standard random generator if no generator was given.
     if not color_generator:
-        color_generator = _random_color_generator()
+        color_generator = random_color_generator()
 
     # Create a palette editor for each offset collection.
     palette_editors = [PaletteEditor(rom, offsets) for offsets in offsets_iterator]
@@ -134,7 +134,7 @@ def randomize_from_options(options):
         output_path = append_to_file_name(input_path, "-rand-pal")
 
     # Define color-generating function.
-    next_color = _random_color_generator(options.pop("seed", -1))
+    next_color = random_color_generator(options.pop("seed", -1))
 
     # Read ROM data from file.
     with open(input_path, mode="rb") as stream:

--- a/maseya/z3pr/palette_randomizer.py
+++ b/maseya/z3pr/palette_randomizer.py
@@ -4,7 +4,7 @@ import json
 import os
 from random import Random
 
-from typing import List
+from typing import List, Mapping
 
 from .color_f import ColorF
 from .palette_editor import PaletteEditor
@@ -23,7 +23,9 @@ def _read_internal_json(json_path: str, json_dir: str = None):
         return json.load(stream)
 
 
-def build_offsets_array(options: dict, json_dir: str = None):
+def build_offsets_array(
+    options: Mapping[str, bool], json_dir: str = None
+) -> List[List[int]]:
     """Build offset array from several offset arrays."""
 
     def try_get_offset_array(name: str) -> List[int]:

--- a/maseya/z3pr/snes_color.py
+++ b/maseya/z3pr/snes_color.py
@@ -122,16 +122,16 @@ class SnesColor:
             convert_channel(self.blue),
         )
 
-    def __eq__(self, value):
+    def __eq__(self, value) -> bool:
         return isinstance(value, SnesColor) and value.value == self.__value
 
-    def __ne__(self, value):
+    def __ne__(self, value) -> bool:
         return not self == value
 
     def __str__(self) -> str:
         return f"{{R:{self.red};G:{self.green};B:{self.blue}}}"
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return str(self)
 
     def __hash__(self) -> int:


### PR DESCRIPTION
* In `PaletteEditor`, refactor blend function's color generators to use
  iterators instead of function pointers. Iterators are much more
  versatile and appropriate here.
* Add function `cache_offsets_array`, which loads all JSON data into
  memory as a dictionary.
* Add function `iterate_offsets_array_cache` which iterates the offset
  arrays of a JSON offset cache based on the `options` parameter you
  pass in. This lets you access the offset data without repeated copies
  or file I/O.
* Make `_random_color_generator` a public function and change its
  return type to an iterable.
* Refactor `randomize` function to accept an `offsets_iterator` instead
  of an `options` dictionary. This lets the user pass in their own
  offsets array rather than the program automatically building its own.
  Automatic offset building is now handled in `randomize_from_options`.
* Add unit tests for randomizing from cached offsets.

@berserker66, how I see you using this is calling `offsets_array_cache = cache_offsets_array()` in your server-side code, and then after a request is made, you call `offsets_iterator = iterate_offsets_array_cache(offsets_array_cache, options)` to get only the offsets requires (e.g. just dungeon and overworld). From there, you pass `offsets_iterator` to the `randomize` function. I made a test which hopefully shows an example [here](https://github.com/Maseya/z3pr-py/blob/cache-offsets/tests/palette_randomize_test.py#L217).

I've also made public to my API this function:
```python
def random_color_generator(seed: int = -1) -> Iterable[ColorF]:
    """Infinitely iterates random colors with an optional seed value."""
    random = Random(seed) if seed != -1 else Random()

    while True:
        yield ColorF(random.random(), random.random(), random.random())
```

With it, you can have deterministic random values. No need to have this code repeated in your multiworld app.